### PR TITLE
Update authors_configuration.yaml

### DIFF
--- a/process/document_metadata_processing/ltc_doc_list/authors_configuration.yaml
+++ b/process/document_metadata_processing/ltc_doc_list/authors_configuration.yaml
@@ -45,7 +45,7 @@
   contributor_literal: Jutta Buschbom
   contributor_role: contributor
   role_uri: http://www.wikidata.org/entity/Q20204892
-  affiliation: Statistical Genetics (Ahrensburg, DE) & Natural History Museum
+  affiliation: Statistical Genetics (Ahrensburg, DE) & Natural History Museum, London
   affiliation_uri: http://www.wikidata.org/entity/Q309388
 
 - contributor_iri: https://orcid.org/0000-0002-0596-5376
@@ -59,7 +59,7 @@
   contributor_literal: Ben Norton
   contributor_role: contributor
   role_uri: http://www.wikidata.org/entity/Q20204892
-  affiliation: Ecosystem Planning & Restoration
+  affiliation: Ecosystem Planning & Restoration (Raleigh, NC, US)
   affiliation_uri:
 
 - contributor_iri: https://orcid.org/0000-0003-4441-6852


### PR DESCRIPTION
Two changes:
1. added "London" to my second affiliation to align with Matt's and Sarah's entries
2. added place to Ben's entry to align with approach in my first affiliation (both companies don't seem to be present in wikidata).